### PR TITLE
Updates 2021-02-05

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
 language: r
-sudo: false
 cache: packages
+os: linux
+dist: xenial
 
 r:
- - release
- - devel
+  - 3.5
+  - oldrel
+  - release
+  - devel
 
 after_success:
- - Rscript -e 'covr::codecov()'
+  - Rscript -e 'covr::codecov()'
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ os: linux
 dist: xenial
 
 r:
-  - 3.5
   - oldrel
   - release
   - devel

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,4 +48,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: TRUE
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: nanostringr
 Title: Performs Quality Control, Data Normalization, and Batch
     Effect Correction for 'NanoString nCounter' Data
-Version: 0.1.4.9000
+Version: 0.2.0
 Authors@R: 
     c(person(given = "Derek",
              family = "Chiu",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,8 @@ Description: Provides quality control (QC), normalization, and
     NanoString data can be imported in the form of Reporter Code Count
     (RCC) files.
 License: MIT + file LICENSE
-URL: https://github.com/TalhoukLab/nanostringr,
-    https://talhouklab.github.io/nanostringr
+URL: https://github.com/TalhoukLab/nanostringr/,
+    https://talhouklab.github.io/nanostringr/
 BugReports: https://github.com/TalhoukLab/nanostringr/issues
 Depends: 
     R (>= 3.5.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # nanostringr (development version)
 
+* use RCC file names in parsed data of `read_rcc()`. Also rename gene name CD3E to CD3e for compatibility purposes
+
+* update roxygen
+
+* remove Rplots.pdf generated from tests, removed deprecated `context()`
+
 # nanostringr 0.1.4
 
 * reduce package dependencies from Imports

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# nanostringr (development version)
+# nanostringr 0.2.0
 
 * use RCC file names in parsed data of `read_rcc()`. Also rename gene name CD3E to CD3e for compatibility purposes
 

--- a/R/read_rcc.R
+++ b/R/read_rcc.R
@@ -38,7 +38,7 @@ read_rcc <- function(path = ".") {
   }
   rcc_files <-
     list.files(path, pattern = "\\.RCC$", full.names = TRUE, ignore.case = TRUE) %>%
-    rlang:::set_names(tools::file_path_sans_ext(basename(.)))
+    rlang::set_names(tools::file_path_sans_ext(basename(.)))
   raw <- rcc_files %>%
     purrr::map(parse_counts) %>%
     purrr::imap(~ `names<-`(.x, c(names(.x)[-4], .y))) %>%

--- a/R/read_rcc.R
+++ b/R/read_rcc.R
@@ -38,12 +38,12 @@ read_rcc <- function(path = ".") {
   }
   rcc_files <-
     list.files(path, pattern = "\\.RCC$", full.names = TRUE, ignore.case = TRUE) %>%
-    purrr::set_names(tools::file_path_sans_ext(basename(.)))
+    rlang:::set_names(tools::file_path_sans_ext(basename(.)))
   raw <- rcc_files %>%
     purrr::map(parse_counts) %>%
     purrr::imap(~ `names<-`(.x, c(names(.x)[-4], .y))) %>%
     purrr::reduce(dplyr::inner_join, by = c("Code.Class", "Name", "Accession")) %>%
-    dplyr::mutate(Name = ifelse(Name == "CD3E", "CD3e", Name)) %>%
+    dplyr::mutate(Name := ifelse(Name == "CD3E", "CD3e", .data$Name)) %>%
     as.data.frame()
   exp <- rcc_files %>%
     purrr::map_df(parse_attributes, .id = "File.Name") %>%

--- a/R/read_rcc.R
+++ b/R/read_rcc.R
@@ -68,7 +68,6 @@ parse_counts <- function(file) {
     dplyr::as_tibble()
 }
 
-#' @inheritParams parse_counts
 #' @name rcc
 #' @return `parse_attributes()` reads a single RCC file and returns a list of
 #'   parsed attributes.

--- a/R/read_rcc.R
+++ b/R/read_rcc.R
@@ -43,7 +43,7 @@ read_rcc <- function(path = ".") {
     purrr::map(parse_counts) %>%
     purrr::imap(~ `names<-`(.x, c(names(.x)[-4], .y))) %>%
     purrr::reduce(dplyr::inner_join, by = c("Code.Class", "Name", "Accession")) %>%
-    dplyr::mutate(Name := ifelse(Name == "CD3E", "CD3e", .data$Name)) %>%
+    dplyr::mutate(!!"Name" := ifelse(.data$Name == "CD3E", "CD3e", .data$Name)) %>%
     as.data.frame()
   exp <- rcc_files %>%
     purrr::map_df(parse_attributes, .id = "File.Name") %>%

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Test environments
 * local OS X install, R 4.0.3
-* ubuntu 16.04 (on travis-ci), R 3.5, oldrel, release, devel
+* ubuntu 16.04 (on travis-ci), R oldrel, release, devel
 * win-builder (devel)
 
 ## R CMD check results

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,7 @@
 ## Test environments
-* local OS X install, R 3.5.1
-* ubuntu 14.04 (on travis-ci), R 3.5.1
-* win-builder (devel and release)
+* local OS X install, R 4.0.3
+* ubuntu 16.04 (on travis-ci), R 3.5, oldrel, release, devel
+* win-builder (devel)
 
 ## R CMD check results
 

--- a/man/CCplot.Rd
+++ b/man/CCplot.Rd
@@ -4,9 +4,19 @@
 \alias{CCplot}
 \title{Concordance Correlation Plot}
 \usage{
-CCplot(method1, method2, Ptype = "None", metrics = FALSE,
-  xlabel = "", ylabel = "", title = "", subtitle = NULL,
-  xrange = NULL, yrange = NULL, MArange = c(-3.5, 5.5))
+CCplot(
+  method1,
+  method2,
+  Ptype = "None",
+  metrics = FALSE,
+  xlabel = "",
+  ylabel = "",
+  title = "",
+  subtitle = NULL,
+  xrange = NULL,
+  yrange = NULL,
+  MArange = c(-3.5, 5.5)
+)
 }
 \arguments{
 \item{method1}{measurements obtained in batch 1 or using method 1}

--- a/man/cohort.Rd
+++ b/man/cohort.Rd
@@ -9,7 +9,8 @@
 \alias{hlo.r}
 \alias{ovo.r}
 \title{NanoString Experiment Cohorts}
-\format{\itemize{
+\format{
+\itemize{
 \item \code{hld.r} Hodgkin Lymphoma Clinical Samples: a data frame with 232 rows and
 77 columns
 \item \code{ovd.r} Ovarian Cancer Clinical Samples: a data frame with 133 rows and 261
@@ -20,7 +21,18 @@ columns
 and 71 columns
 \item \code{ovo.r} DNA Oligonucleotides for the OC CodeSet: a data frame with 133 rows
 and 138 columns
-}}
+}
+
+An object of class \code{data.frame} with 232 rows and 77 columns.
+
+An object of class \code{data.frame} with 133 rows and 261 columns.
+
+An object of class \code{data.frame} with 133 rows and 29 columns.
+
+An object of class \code{data.frame} with 40 rows and 71 columns.
+
+An object of class \code{data.frame} with 133 rows and 138 columns.
+}
 \source{
 See Table 1 of
 \url{https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0153844}

--- a/man/expQC.Rd
+++ b/man/expQC.Rd
@@ -3,7 +3,9 @@
 \name{expQC}
 \alias{expQC}
 \title{Expression QC data}
-\format{A data frame with 561 rows and 23 columns.}
+\format{
+A data frame with 561 rows and 23 columns.
+}
 \description{
 Quality control metrics for the five cohorts analyzed in NanoString
 experiments.

--- a/man/nanostringr-package.Rd
+++ b/man/nanostringr-package.Rd
@@ -19,8 +19,8 @@ Provides quality control (QC), normalization, and
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/TalhoukLab/nanostringr}
-  \item \url{https://talhouklab.github.io/nanostringr}
+  \item \url{https://github.com/TalhoukLab/nanostringr/}
+  \item \url{https://talhouklab.github.io/nanostringr/}
   \item Report bugs at \url{https://github.com/TalhoukLab/nanostringr/issues}
 }
 

--- a/man/rcc.Rd
+++ b/man/rcc.Rd
@@ -39,7 +39,7 @@ parsed attributes.
 }
 \description{
 Read RCC files and extract count and attribute data. Use \code{read_rcc()} for
-multiple files, and use the \code{parse_*()} functions for single files.
+multiple files, and use the \verb{parse_*()} functions for single files.
 }
 \details{
 RCC files for a sample are direct outputs from NanoString runs. We can

--- a/tests/testthat/test-CCplot.R
+++ b/tests/testthat/test-CCplot.R
@@ -1,5 +1,3 @@
-context("CCplot")
-
 set.seed(12)
 a1 <- rnorm(20)
 a2 <- rnorm(20) + 2

--- a/tests/testthat/test-CCplot.R
+++ b/tests/testthat/test-CCplot.R
@@ -18,3 +18,7 @@ test_that("Metrics have correct structure", {
   expect_is(m, "numeric")
   expect_length(m, 3)
 })
+
+dev.off()
+if (file.exists("Rplots.pdf")) file.remove("Rplots.pdf")
+

--- a/tests/testthat/test-HKnorm.R
+++ b/tests/testthat/test-HKnorm.R
@@ -1,5 +1,3 @@
-context("HKnorm")
-
 data(ovd.r)
 
 test_that("No error on either scale", {

--- a/tests/testthat/test-NanoStringQC.R
+++ b/tests/testthat/test-NanoStringQC.R
@@ -1,5 +1,3 @@
-context("NanoStringQC")
-
 data("expQC", "hld.r", "hlo.r", "ovc.r", "ovd.r", "ovo.r")
 
 test_that("Error if raw and exp different number of columns", {

--- a/tests/testthat/test-order.R
+++ b/tests/testthat/test-order.R
@@ -1,7 +1,4 @@
-
-context("Orderings")
-
-library(dplyr)
+library(magrittr)
 set.seed(1)
 logXpr <- replicate(5, rnorm(6))
 dim(logXpr)

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1,5 +1,3 @@
-context("Parse RCC files")
-
 rcc_file <- system.file("extdata", "example.RCC", package = "nanostringr")
 
 test_that("reading from directory outputs list of counts and attributes", {

--- a/tests/testthat/test-ratioMethod.R
+++ b/tests/testthat/test-ratioMethod.R
@@ -1,5 +1,3 @@
-context("refMethod")
-
 set.seed(12)
 A <- matrix(rnorm(120), ncol = 10)
 B <- matrix(rnorm(80), ncol = 10)


### PR DESCRIPTION
- In `read_rcc()`, the element `raw` now uses the file names instead of just sample ID as column headers to better differentiate samples with similar IDs (pool samples)
- Similarly, the `File.Name` column in the `exp` element of `read_rcc()` now uses file names
- Updated roxygen version, travis CI
- Removed deprecated `context()` from tests